### PR TITLE
EntrustVersionInfo extension implementation

### DIFF
--- a/packages/x509/README.md
+++ b/packages/x509/README.md
@@ -5,4 +5,9 @@
 
 [![NPM](https://nodei.co/npm/@peculiar/asn1-x509.png)](https://nodei.co/npm/@peculiar/asn1-x509/)
 
-[RFC 5280](https://tools.ietf.org/html/rfc5280) Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile
+[RFC 5280](https://tools.ietf.org/html/rfc5280) Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile.
+
+
+## List of links
+
+- [EntrustVersionInfo](http://ftp.gnome.org/mirror/archive/ftp.sunet.se/pub/security/dfnpca/docs/misc/Entrust/directory.pdf) extension

--- a/packages/x509/src/extensions/entrust_version_info.ts
+++ b/packages/x509/src/extensions/entrust_version_info.ts
@@ -1,0 +1,67 @@
+import { AsnProp, AsnPropTypes, BitString } from "@peculiar/asn1-schema";
+
+/**
+ * ```
+ * id-entrust-entrustVersInfo      OBJECT IDENTIFIER ::= {iso(1)
+ *   member-body(2) us(840) nortelnetworks(113533) entrust(7)
+ *   nsn-ce(65) 0}
+ * ```
+ */
+export const id_entrust_entrustVersInfo = "1.2.840.113533.7.65.0";
+
+export type EntrustInfoType = "keyUpdateAllowed" | "newExtensions" | "pKIXCertificate";
+
+export enum EntrustInfoFlags {
+  keyUpdateAllowed = 0x0001,
+  newExtensions = 0x0002,
+  pKIXCertificate = 0x0004,
+}
+
+/**
+ * ```
+ * EntrustInfoFlags ::= BIT STRING {
+ *   keyUpdateAllowed        (0),
+ *   newExtensions           (1),  -- not used
+ *   pKIXCertificate         (2) } -- certificate created by pkix
+ * ```
+ */
+export class EntrustInfo extends BitString {
+  public toJSON() {
+    const res: EntrustInfoType[] = [];
+    const flags = this.toNumber();
+    if (flags & EntrustInfoFlags.pKIXCertificate) {
+      res.push("pKIXCertificate");
+    }
+    if (flags & EntrustInfoFlags.newExtensions) {
+      res.push("newExtensions");
+    }
+    if (flags & EntrustInfoFlags.keyUpdateAllowed) {
+      res.push("keyUpdateAllowed");
+    }
+    return res;
+  }
+
+  public toString() {
+    return `[${this.toJSON().join(", ")}]`;
+  }
+}
+
+/**
+ * ```
+ * EntrustVersionInfo ::= SEQUENCE {
+ *     entrustVers	GeneralString,
+ *     entrustInfoFlags	EntrustInfoFlags }
+ * ```
+ */
+export class EntrustVersionInfo {
+
+  @AsnProp({ type: AsnPropTypes.GeneralString })
+  public entrustVers = '';
+
+  @AsnProp({ type: EntrustInfo })
+  public entrustInfoFlags = new EntrustInfo();
+
+  constructor(params: Partial<EntrustVersionInfo> = {}) {
+    Object.assign(this, params);
+  }
+}

--- a/packages/x509/src/extensions/index.ts
+++ b/packages/x509/src/extensions/index.ts
@@ -17,3 +17,4 @@ export * from "./subject_alternative_name";
 export * from "./subject_directory_attributes";
 export * from "./subject_key_identifier";
 export * from "./private_key_usage_period";
+export * from "./entrust_version_info";

--- a/packages/x509/test/x509.ts
+++ b/packages/x509/test/x509.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import { AsnParser, AsnConvert } from "@peculiar/asn1-schema";
 import { Convert } from "pvtsutils";
-import { Certificate, id_ce_cRLDistributionPoints, CRLDistributionPoints, id_ce_keyUsage, KeyUsage, id_ce_extKeyUsage, ExtendedKeyUsage, NameConstraints, GeneralSubtrees, GeneralSubtree, GeneralName, UserNotice, PrivateKeyUsagePeriod } from "../src";
+import { Certificate, id_ce_cRLDistributionPoints, CRLDistributionPoints, id_ce_keyUsage, KeyUsage, id_ce_extKeyUsage, ExtendedKeyUsage, NameConstraints, GeneralSubtrees, GeneralSubtree, GeneralName, UserNotice, PrivateKeyUsagePeriod, EntrustVersionInfo } from "../src";
 import { CertificateTemplate } from "@peculiar/asn1-x509-microsoft";
 
 context("x509", () => {
@@ -107,6 +107,16 @@ context("x509", () => {
 
     assert.strictEqual(privateKeyUsagePeriod.notBefore?.getTime(), 1042069043000);
     assert.strictEqual(privateKeyUsagePeriod.notAfter?.getTime(), 1673222843000);
+  });
+
+  it("EntrustVersionInfo", () => {
+    const hex = "300e1b0856362e303a342e3003020490";
+    const raw = Buffer.from(hex, "hex");
+
+    const entrustVersionInfo = AsnConvert.parse(raw, EntrustVersionInfo);
+
+    assert.strictEqual(entrustVersionInfo.entrustVers, "V6.0:4.0");
+    assert.strictEqual(entrustVersionInfo.entrustInfoFlags.toString(), "[keyUpdateAllowed]");
   });
 
 });


### PR DESCRIPTION
Related with https://github.com/PeculiarVentures/pv-certificates-viewer/issues/66.

Schema source - https://metacpan.org/source/MNUNBERG/Crypt-OpenSSL-Cloner-0.04/lib/Crypt/OpenSSL/Cloner/x509asn1.pm#L223.