### PR TITLE
chore: remove dependency on dom lib

### DIFF
--- a/packages/cert-transparency/src/byte_stream.ts
+++ b/packages/cert-transparency/src/byte_stream.ts
@@ -1,5 +1,5 @@
 
-import { BufferSourceConverter, Convert } from "pvtsutils";
+import { BufferSource, BufferSourceConverter, Convert } from "pvtsutils";
 
 export class ByteStream {
   protected view: Uint8Array;

--- a/packages/cert-transparency/src/structure.ts
+++ b/packages/cert-transparency/src/structure.ts
@@ -1,4 +1,4 @@
-import { BufferSourceConverter } from "pvtsutils";
+import { BufferSource, BufferSourceConverter } from "pvtsutils";
 import { ByteStream } from "./byte_stream";
 
 export abstract class Structure {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@types/asn1js": "^0.0.2",
     "asn1js": "^2.0.26",
-    "pvtsutils": "^1.0.14",
+    "pvtsutils": "^1.0.15",
     "tslib": "^2.0.2"
   },
   "contributors": [

--- a/packages/schema/src/convert.ts
+++ b/packages/schema/src/convert.ts
@@ -1,3 +1,4 @@
+import type { BufferSource } from "pvtsutils";
 import { AsnParser } from "./parser";
 import { IEmptyConstructor } from "./types";
 import { AsnSerializer } from "./serializer";

--- a/packages/schema/src/parser.ts
+++ b/packages/schema/src/parser.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import * as asn1 from "asn1js";
+import type { BufferSource } from "pvtsutils";
 import { AsnPropTypes, AsnTypeTypes } from "./enums";
 import * as converters from "./converters";
 import { AsnSchemaValidationError } from "./errors";

--- a/packages/schema/src/types/bit_string.ts
+++ b/packages/schema/src/types/bit_string.ts
@@ -1,5 +1,5 @@
 import { BitString as AsnBitString } from "asn1js";
-import { BufferSourceConverter } from "pvtsutils";
+import { BufferSource, BufferSourceConverter } from "pvtsutils";
 import { IAsnConvertible } from "../types";
 
 export class BitString<T extends number = number> implements IAsnConvertible {

--- a/packages/schema/src/types/octet_string.ts
+++ b/packages/schema/src/types/octet_string.ts
@@ -1,5 +1,5 @@
 import { OctetString as AsnOctetString } from "asn1js";
-import { BufferSourceConverter } from "pvtsutils";
+import { BufferSource, BufferSourceConverter } from "pvtsutils";
 import { IAsnConvertible } from "../types";
 
 // Implement ArrayBufferView, cause ES5 doesn't allow to extend ArrayBuffer class

--- a/tsconfig.compile.json
+++ b/tsconfig.compile.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "lib": [
+      "ES2015"
+    ],
     "incremental": true,
     "target": "ES2015",
     "module": "CommonJS",


### PR DESCRIPTION
The dom lib is incompatible with node, so using it to reference type
definitions forces downstream projects to use the --skipLibCheck
TypeScript option.

The BufferSource type is sourced from the pvtsutils package instead.

----------

👋 Hi, this PR would follow https://github.com/PeculiarVentures/pvtsutils/pull/3 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49322 (since we need `@types/asn1js` to not pull in the dependency on `@types/pvutils` which has a dom lib dependency).

Of course, it isn't necessary to get the `BufferSource` type alias from `pvtsutils`, but I inferred that importing it from there would be preferable based on how the `pvtsutils` package is consumed across your packages.