### PR TITLE
Fix issues with OCSPResponse and associated definitions

### DIFF
--- a/packages/ocsp/src/response_data.ts
+++ b/packages/ocsp/src/response_data.ts
@@ -28,7 +28,7 @@ export class ResponseData {
   @AsnProp({ type: SingleResponse, repeated: "sequence" })
   public responses: SingleResponse[] = [];
 
-  @AsnProp({ type: Extension, repeated: "sequence", context: 0, optional: true })
+  @AsnProp({ type: Extension, repeated: "sequence", context: 1, optional: true })
   public responseExtensions?: Extension[];
 
   constructor(params: Partial<ResponseData> = {}) {

--- a/packages/ocsp/src/single_response.ts
+++ b/packages/ocsp/src/single_response.ts
@@ -27,7 +27,7 @@ export class SingleResponse {
   @AsnProp({ type: AsnPropTypes.GeneralizedTime })
   public thisUpdate = new Date();
 
-  @AsnProp({ type: AsnPropTypes.GeneralizedTime, context: 0 })
+  @AsnProp({ type: AsnPropTypes.GeneralizedTime, context: 0, optional: true })
   public nextUpdate?: Date;
 
   @AsnProp({ type: Extension, context: 1, repeated: "sequence", optional: true })

--- a/packages/ocsp/src/single_response.ts
+++ b/packages/ocsp/src/single_response.ts
@@ -21,7 +21,7 @@ export class SingleResponse {
   @AsnProp({ type: CertID })
   public certID = new CertID();
 
-  @AsnProp({ type: CertID })
+  @AsnProp({ type: CertStatus })
   public certStatus = new CertStatus();
 
   @AsnProp({ type: AsnPropTypes.GeneralizedTime })


### PR DESCRIPTION
When attempting to parse OCSP responses from a server, several definitions failed to pass successfully:

1. ResponseData.Extension should needs contextual tag `[1]`
2. certStatus was mis-defined as CertID instead of CertStatus
3. nextUpdate property is optional