### PR TITLE
Null valueBlock does not have toBeR()

### DIFF
--- a/packages/schema/src/serializer.ts
+++ b/packages/schema/src/serializer.ts
@@ -69,7 +69,7 @@ export class AsnSerializer {
             if (!schemaItem.repeated
               && (typeof schemaItem.type === "number" || isConvertible(schemaItem.type))) {
               const value: { valueHex?: ArrayBuffer, value?: ArrayBuffer } = {};
-              value.valueHex = asn1Item.valueBlock.toBER();
+              value.valueHex = asn1Item instanceof asn1.Null ? asn1Item.valueBeforeDecode: asn1Item.valueBlock.toBER();
               asn1Value.push(new asn1.Primitive({
                 optional: schemaItem.optional,
                 idBlock: {


### PR DESCRIPTION
When performing an encoding of a `ResponseData` object I came across the error `TypeError: asn1Item.valueBlock.toBER is not a function`

It turns out that the `valueBlock` on a `Null` ASN1 object does not have a `toBER` function. I'm not sure if it's best to fix this here with some kind of handling of empty / null objects or if the underlying asn1js library should add the `toBER` onto the `LocalBaseBlock`. However, this fixed the problem for me.

I think this issue comes when there is an explicit tag but also a default value (so it can be left empty).

```
ResponseData ::= SEQUENCE {
   version             [0] EXPLICIT Version DEFAULT v1,
   responderID             ResponderID,
   producedAt              GeneralizedTime,
   responses               SEQUENCE OF SingleResponse,
   responseExtensions  [1] EXPLICIT Extensions OPTIONAL }
```