### PR TITLE
Add sha224WithRSAEncryption const without typo

### DIFF
--- a/packages/rsa/src/object_identifiers.ts
+++ b/packages/rsa/src/object_identifiers.ts
@@ -60,7 +60,8 @@ export const id_sha1WithRSAEncryption = `${id_pkcs_1}.5`;
  * sha224WithRSAEncryption      OBJECT IDENTIFIER ::= { pkcs-1 14 }
  * ```
  */
-export const id_ssha224WithRSAEncryption = `${id_pkcs_1}.14`;
+export const id_sha224WithRSAEncryption = `${id_pkcs_1}.14`;
+export const id_ssha224WithRSAEncryption = id_sha224WithRSAEncryption;
 
 /**
  * ```

--- a/packages/rsa/src/object_identifiers.ts
+++ b/packages/rsa/src/object_identifiers.ts
@@ -61,6 +61,12 @@ export const id_sha1WithRSAEncryption = `${id_pkcs_1}.5`;
  * ```
  */
 export const id_sha224WithRSAEncryption = `${id_pkcs_1}.14`;
+/**
+ * ```
+ * sha224WithRSAEncryption      OBJECT IDENTIFIER ::= { pkcs-1 14 }
+ * ```
+ * @deprecated Should be removed later
+ */
 export const id_ssha224WithRSAEncryption = id_sha224WithRSAEncryption;
 
 /**


### PR DESCRIPTION
I noticed this constant is typo-ed.

Instead of removing the existing typo, I've added one without so that existing imports won't break in any dependant projects.