### PR TITLE
fix cms EncryptedContent format

### DIFF
--- a/packages/cms/src/encrypted_content_info.ts
+++ b/packages/cms/src/encrypted_content_info.ts
@@ -1,12 +1,5 @@
-import { AsnProp, AsnPropTypes, AsnType, AsnTypeTypes, OctetString } from "@peculiar/asn1-schema";
+import { AsnConstructedOctetStringConverter, AsnProp, AsnPropTypes, AsnType, AsnTypeTypes, OctetString } from "@peculiar/asn1-schema";
 import { ContentType, ContentEncryptionAlgorithmIdentifier } from "./types";
-
-/**
- * ```asn
- * EncryptedContent ::= OCTET STRING
- * ```
- */
-export type PrimitiveEncryptedContent = OctetString;
 
 /**
  * ```asn
@@ -16,45 +9,15 @@ export type PrimitiveEncryptedContent = OctetString;
 @AsnType({ type: AsnTypeTypes.Choice })
 export class EncryptedContent {
 
-  @AsnProp({ type: OctetString })
-  public single?: OctetString;
+  // primitive OctetString
+  @AsnProp({ type: OctetString, context: 0, implicit: true, optional: true })
+  public value?: OctetString;
 
-  @AsnProp({ type: AsnPropTypes.Any })
-  public any?: ArrayBuffer;
+  // constructed OctetString (custom converter is needed to create new instances inside "repeated")
+  @AsnProp({ type: OctetString, converter: AsnConstructedOctetStringConverter, context: 0, implicit: true, optional: true, repeated: "sequence" })
+  public constructedValue?: OctetString[];
 
   constructor(params: Partial<EncryptedContent> = {}) {
-    Object.assign(this, params);
-  }
-}
-
-export class ImplicitEncryptedContentInfo {
-
-  @AsnProp({ type: AsnPropTypes.ObjectIdentifier })
-  public contentType: ContentType = "";
-
-  @AsnProp({ type: ContentEncryptionAlgorithmIdentifier })
-  public contentEncryptionAlgorithm = new ContentEncryptionAlgorithmIdentifier();
-
-  @AsnProp({ type: OctetString, context: 0, implicit: true, optional: true })
-  public encryptedContent?: PrimitiveEncryptedContent;
-
-  constructor(params: Partial<ImplicitEncryptedContentInfo> = {}) {
-    Object.assign(this, params);
-  }
-}
-
-export class ExplicitEncryptedContentInfo {
-
-  @AsnProp({ type: AsnPropTypes.ObjectIdentifier })
-  public contentType: ContentType = "";
-
-  @AsnProp({ type: ContentEncryptionAlgorithmIdentifier })
-  public contentEncryptionAlgorithm = new ContentEncryptionAlgorithmIdentifier();
-
-  @AsnProp({ type: EncryptedContent, context: 0, optional: true })
-  public encryptedContent?: EncryptedContent;
-
-  constructor(params: Partial<ExplicitEncryptedContentInfo> = {}) {
     Object.assign(this, params);
   }
 }
@@ -67,16 +30,16 @@ export class ExplicitEncryptedContentInfo {
  *  encryptedContent [0] IMPLICIT EncryptedContent OPTIONAL }
  * ```
  */
-@AsnType({ type: AsnTypeTypes.Choice })
 export class EncryptedContentInfo {
 
-  // RFC compliant
-  @AsnProp({ type: ImplicitEncryptedContentInfo, optional: true })
-  public implicitEncryptedContentInfo?: ImplicitEncryptedContentInfo;
+  @AsnProp({ type: AsnPropTypes.ObjectIdentifier })
+  public contentType: ContentType = "";
 
-  // !!! Non RFC compliant but used by modern crypto libraries
-  @AsnProp({ type: ExplicitEncryptedContentInfo, optional: true })
-  public explicitEncryptedContentInfo?: ExplicitEncryptedContentInfo;
+  @AsnProp({ type: ContentEncryptionAlgorithmIdentifier })
+  public contentEncryptionAlgorithm = new ContentEncryptionAlgorithmIdentifier();
+
+  @AsnProp({ type: EncryptedContent, optional: true })
+  public encryptedContent?: EncryptedContent;
 
   constructor(params: Partial<EncryptedContentInfo> = {}) {
     Object.assign(this, params);

--- a/packages/cms/test/test.ts
+++ b/packages/cms/test/test.ts
@@ -1,4 +1,4 @@
-import { AsnConvert, AsnParser } from "@peculiar/asn1-schema";
+import { AsnConvert } from "@peculiar/asn1-schema";
 import * as assert from "assert";
 import { Convert } from "pvtsutils";
 import { ContentInfo, EncapsulatedContentInfo, EnvelopedData, id_data, id_envelopedData, id_signedData, SignedData, SignerIdentifier } from "../src";
@@ -34,10 +34,10 @@ context("cms", () => {
       "xscwrRK2g4RdhmFvHhT3RKZT12p+NZqexzkkMIYso+DCYFT66Fy+yC9uTJ/7rARq" +
       "d4sO/vmLB9MFCMbdvsEJNvj/4/tedg8cAAAAAAAA";
 
-    const contentInfo = AsnParser.parse(Convert.FromBase64(pem), ContentInfo);
+    const contentInfo = AsnConvert.parse(Convert.FromBase64(pem), ContentInfo);
     assert.strictEqual(contentInfo.contentType, id_signedData);
 
-    const signedData = AsnParser.parse(contentInfo.content, SignedData);
+    const signedData = AsnConvert.parse(contentInfo.content, SignedData);
     assert.strictEqual(!!signedData, true);
 
     const signer = signedData.signerInfos[0];
@@ -93,7 +93,7 @@ context("cms", () => {
     it("parse constructed OCTET STREAM", () => {
       const pem = "MIAGCSqGSIb3DQEHAaCAJIAAAAAAAAA=";
 
-      const contentInfo = AsnParser.parse(Convert.FromBase64(pem), EncapsulatedContentInfo);
+      const contentInfo = AsnConvert.parse(Convert.FromBase64(pem), EncapsulatedContentInfo);
       assert.strictEqual(contentInfo.eContentType, id_data);
       assert.strictEqual(contentInfo.eContent?.any?.byteLength, 4);
     });
@@ -101,7 +101,7 @@ context("cms", () => {
     it("parse single OCTET STREAM", () => {
       const pem = "308006092A864886F70D010701A080040000000000";
 
-      const contentInfo = AsnParser.parse(Convert.FromHex(pem), EncapsulatedContentInfo);
+      const contentInfo = AsnConvert.parse(Convert.FromHex(pem), EncapsulatedContentInfo);
       assert.strictEqual(contentInfo.eContentType, id_data);
       assert.strictEqual(contentInfo.eContent?.single?.byteLength, 0);
     });
@@ -120,23 +120,10 @@ context("cms", () => {
 
     const contentInfoPEMs = [
       {
-        implicit: false,
+        constructed: false,
         type: "KeyTransfer",
-        pem: "MIAGCSqGSIb3DQEHA6CAMIACAQIxggFcMIIBWAIBADBAMCsxKTAnBgNVBAMeIAB0" +
-          "AGUAcwB0AEAAZQB4AGEAbQBwAGwAZQAuAGMAbwBtAhEArCY1BXmx0dEycmMiIYRa" +
-          "cDANBgkqhkiG9w0BAQEFAASCAQAfvvx+Gp/pI4NciVPywwu1l3ivfZ1K7s10RTf4" +
-          "jgclZn3ShOvBDsxbnf/KcgpxIeKo3Ik6xHCS9TEu0caVb41VBsKKeHd3vfkeCFjO" +
-          "kctoTiFoi03G5vZqAHBXOsM+9ngl2YYob22Wp9DPh6TuHzmyWNJv6XU86RePEk0m" +
-          "O6bxRucYNyryOSy1tGnw1BksJdsKxJHsM93WpTNfJUPRM5GQpLnL4swE/czubnqL" +
-          "LjeuAmGSWxjMgJCFBhEa1vGI85MlB5HVgMedlu/DlnKdTTKPATEX4HNVlTkxjw4U" +
-          "QFbqLJUkZLYGt+PXMlbpTdC8o3Flh8z7NsbBCtjnCqEqjO+9MIAGCSqGSIb3DQEH" +
-          "ATAdBglghkgBZQMEASoEEApTJq854NYO1bqCHf1wlJuggAQQGlV/5YkunKR5KRYg" +
-          "L36BkQAAAAAAAAAAAAA="
-      },
-      {
-        implicit: true,
-        type: "KeyTransfer",
-        pem: "MIIBtAYJKoZIhvcNAQcDoIIBpTCCAaECAQIxggFcMIIBWAIBADBAMCsxKTAnBgNV" +
+        pem:
+          "MIIBtAYJKoZIhvcNAQcDoIIBpTCCAaECAQIxggFcMIIBWAIBADBAMCsxKTAnBgNV" +
           "BAMeIAB0AGUAcwB0AEAAZQB4AGEAbQBwAGwAZQAuAGMAbwBtAhEArCY1BXmx0dEy" +
           "cmMiIYRacDANBgkqhkiG9w0BAQEFAASCAQAfvvx+Gp/pI4NciVPywwu1l3ivfZ1K" +
           "7s10RTf4jgclZn3ShOvBDsxbnf/KcgpxIeKo3Ik6xHCS9TEu0caVb41VBsKKeHd3" +
@@ -148,9 +135,25 @@ context("cms", () => {
           "eSkWIC9+gZE="
       },
       {
-        implicit: false,
+        constructed: true,
+        type: "KeyTransfer",
+        pem:
+          "MIAGCSqGSIb3DQEHA6CAMIACAQIxggFcMIIBWAIBADBAMCsxKTAnBgNVBAMeIAB0" +
+          "AGUAcwB0AEAAZQB4AGEAbQBwAGwAZQAuAGMAbwBtAhEArCY1BXmx0dEycmMiIYRa" +
+          "cDANBgkqhkiG9w0BAQEFAASCAQAfvvx+Gp/pI4NciVPywwu1l3ivfZ1K7s10RTf4" +
+          "jgclZn3ShOvBDsxbnf/KcgpxIeKo3Ik6xHCS9TEu0caVb41VBsKKeHd3vfkeCFjO" +
+          "kctoTiFoi03G5vZqAHBXOsM+9ngl2YYob22Wp9DPh6TuHzmyWNJv6XU86RePEk0m" +
+          "O6bxRucYNyryOSy1tGnw1BksJdsKxJHsM93WpTNfJUPRM5GQpLnL4swE/czubnqL" +
+          "LjeuAmGSWxjMgJCFBhEa1vGI85MlB5HVgMedlu/DlnKdTTKPATEX4HNVlTkxjw4U" +
+          "QFbqLJUkZLYGt+PXMlbpTdC8o3Flh8z7NsbBCtjnCqEqjO+9MIAGCSqGSIb3DQEH" +
+          "ATAdBglghkgBZQMEASoEEApTJq854NYO1bqCHf1wlJuggAQQGlV/5YkunKR5KRYg" +
+          "L36BkQAAAAAAAAAAAAA="
+      },
+      {
+        constructed: true,
         type: "KeyAgreement",
-        pem: "MIAGCSqGSIb3DQEHA6CAMIACAQIxggEvoYIBKwIBA6BboVkwEwYHKoZIzj0CAQYI" +
+        pem:
+          "MIAGCSqGSIb3DQEHA6CAMIACAQIxggEvoYIBKwIBA6BboVkwEwYHKoZIzj0CAQYI" +
           "KoZIzj0DAQcDQgAEXYtv0mvYZS9r3T1ACG1snNX6rHze8c9WvN3GCpMECYnTUwk1" +
           "Oq6WOyZQK5DjOqE9QbvnagIGCeRW1hf0lFUwWqFCBEBicHhjiM0DncuQYs+uleiD" +
           "XUEusztkUu2KgTkmZe5WUuAiEMZZZEEv7rVOgjjOUJPPKrC3BoGe09AIP18vTwUm" +
@@ -159,16 +162,72 @@ context("cms", () => {
           "/PPO0dDEeSaA+ZsPk5kyseTH+oF/17Vv1OOB/vteBuYOBzGvMU8ZMIAGCSqGSIb3" +
           "DQEHATAdBglghkgBZQMEASoEEF/kaKixfwI4FlzjI1SkA5mggAQQJB0YtxHaNhef" +
           "D3JOjs958wAAAAAAAAAAAAA="
-      }
+      },
+      {
+        constructed: true,
+        type: "KeyAgreement",
+        expected_buffer: Buffer.from('hello world; '.repeat(200), 'ascii'),
+        pem:
+          "MIILrwYJKoZIhvcNAQcDoIILoDCCC5wCAQIxggEvoYIBKwIBA6BboVkwEwYHKoZIzj0CAQYIKoZIzj0D" +
+          "AQcDQgAEXYtv0mvYZS9r3T1ACG1snNX6rHze8c9WvN3GCpMECYnTUwk1Oq6WOyZQK5DjOqE9QbvnagIG" +
+          "CeRW1hf0lFUwWqFCBEBicHhjiM0DncuQYs+uleiDXUEusztkUu2KgTkmZe5WUuAiEMZZZEEv7rVOgjjO" +
+          "UJPPKrC3BoGe09AIP18vTwUmMBUGBiuBBAELAzALBglghkgBZQMEAS0wbjBsMEAwKzEpMCcGA1UEAx4g" +
+          "AHQAZQBzAHQAQABlAHgAYQBtAHAAbABlAC4AYwBvAG0CEQDt88GyTDvYPzAPACKBF9GRBCiE/PPO0dDE" +
+          "eSaA+ZsPk5kyseTH+oF/17Vv1OOB/vteBuYOBzGvMU8ZMIIKYgYJKoZIhvcNAQcBMB0GCWCGSAFlAwQB" +
+          "KgQQX+RoqLF/AjgWXOMjVKQDmaCCCjQEggQAaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3" +
+          "b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhl" +
+          "bGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3Js" +
+          "ZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxv" +
+          "IHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsg" +
+          "aGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdv" +
+          "cmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVs" +
+          "bG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxk" +
+          "OyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8g" +
+          "d29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBo" +
+          "ZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29y" +
+          "bGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxs" +
+          "byB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7" +
+          "IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3" +
+          "b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhl" +
+          "bGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3Js" +
+          "ZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxv" +
+          "IHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybASCBABkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29y" +
+          "bGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxs" +
+          "byB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7" +
+          "IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3" +
+          "b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhl" +
+          "bGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3Js" +
+          "ZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxv" +
+          "IHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsg" +
+          "aGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdv" +
+          "cmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVs" +
+          "bG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxk" +
+          "OyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8g" +
+          "d29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBo" +
+          "ZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29y" +
+          "bGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxs" +
+          "byB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7" +
+          "IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3" +
+          "b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3BIICKG9ybGQ7IGhlbGxvIHdvcmxk" +
+          "OyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8g" +
+          "d29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBo" +
+          "ZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29y" +
+          "bGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxs" +
+          "byB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7" +
+          "IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3" +
+          "b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhl" +
+          "bGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3Js" +
+          "ZDsgaGVsbG8gd29ybGQ7IGhlbGxvIHdvcmxkOyBoZWxsbyB3b3JsZDsgaGVsbG8gd29ybGQ7IA=="
+      },
     ]
 
-    for (const { type, implicit, pem } of contentInfoPEMs) {
-      it(`parse CMS with ${type} EnvelopedData - ${implicit ? "implicit" : "explicit"} EncryptedContent`, () => {
+    for (const { type, constructed, pem, expected_buffer } of contentInfoPEMs) {
+      it(`parse CMS with ${type} EnvelopedData - ${constructed ? "constructed" : ""} OctetString`, () => {
         // parse contentInfo
-        const contentInfo = AsnParser.parse(Convert.FromBase64(pem), ContentInfo);
+        const contentInfo = AsnConvert.parse(Convert.FromBase64(pem), ContentInfo);
         assert.strictEqual(contentInfo.contentType, id_envelopedData);
 
-        const envelopedData = AsnParser.parse(contentInfo.content, EnvelopedData);
+        const envelopedData = AsnConvert.parse(contentInfo.content, EnvelopedData);
         assert.strictEqual(!!envelopedData, true);
 
         const recipientInfo = envelopedData.recipientInfos[0];
@@ -188,10 +247,18 @@ context("cms", () => {
         const encryptedContentInfo = envelopedData.encryptedContentInfo;
         assert.strictEqual(!!encryptedContentInfo, true);
 
-        if (implicit) {
-          assert.strictEqual(!!encryptedContentInfo.implicitEncryptedContentInfo?.encryptedContent, true);
+        if (constructed) {
+          const constructedValue = encryptedContentInfo.encryptedContent?.constructedValue;
+          assert.strictEqual(!!constructedValue, true);
+
+          if (constructedValue && expected_buffer) {
+            const actualBuffer = Buffer.concat(
+              constructedValue.map(o => Buffer.from(o.buffer))
+            )
+            assert.notStrictEqual(actualBuffer, expected_buffer);
+          }
         } else {
-          assert.strictEqual(!!encryptedContentInfo.explicitEncryptedContentInfo?.encryptedContent?.single, true);
+          assert.strictEqual(!!encryptedContentInfo.encryptedContent?.value, true);
         }
       })
     }

--- a/packages/schema/src/converters.ts
+++ b/packages/schema/src/converters.ts
@@ -1,6 +1,7 @@
 import * as asn1js from "asn1js";
 import { AnyConverterType, IAsnConverter, IntegerConverterType } from "./types";
 import { AsnPropTypes } from "./enums";
+import { OctetString } from "./types/index";
 /**
  * NOTE: Converter MUST have name Asn<Asn1PropType.name>Converter.
  * Asn1Prop decorator link custom converters by name of the Asn1PropType
@@ -87,6 +88,14 @@ export const AsnBooleanConverter: IAsnConverter<boolean, asn1js.Boolean> = {
 export const AsnOctetStringConverter: IAsnConverter<ArrayBuffer, asn1js.OctetString> = {
   fromASN: (value: asn1js.OctetString) => value.valueBlock.valueHexView,
   toASN: (value: ArrayBuffer) => new asn1js.OctetString({ valueHex: value }),
+};
+
+/**
+ * ASN.1 OCTET_STRING converter to OctetString class
+ */
+export const AsnConstructedOctetStringConverter: IAsnConverter<OctetString, asn1js.OctetString> = {
+  fromASN: (value: asn1js.OctetString) => new OctetString(value.getValue()),
+  toASN: (value: OctetString) => value.toASN(),
 };
 
 function createStringConverter<T extends asn1js.BaseStringBlock>(Asn1Type: new (params: { value: string; }) => T): IAsnConverter<string> {

--- a/packages/schema/test/converters.ts
+++ b/packages/schema/test/converters.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { AsnAnyConverter, AsnGeneralizedTimeConverter, AsnUTCTimeConverter } from "../src";
+import { AsnAnyConverter, AsnConstructedOctetStringConverter, AsnGeneralizedTimeConverter, AsnUTCTimeConverter, OctetString } from "../src";
 
 context("converters", () => {
 
@@ -53,6 +53,19 @@ context("converters", () => {
 
       const value = AsnUTCTimeConverter.fromASN(asn);
       assert.strictEqual(value.getTime(), dateNum);
+    });
+  });
+
+  context("ConstructedOctetStringConverter", () => {
+    const buffer = Buffer.from("12345", 'ascii');
+    it("correct", () => {
+      const asn = AsnConstructedOctetStringConverter.toASN(new OctetString(buffer));
+
+      const der = asn.toBER();
+      assert.strictEqual(Buffer.from(der).toString("hex"), "04053132333435");
+
+      const value = AsnConstructedOctetStringConverter.fromASN(asn);
+      assert.notStrictEqual(Buffer.from(value.buffer), buffer);
     });
   });
 });


### PR DESCRIPTION
This is a follow-up to https://github.com/PeculiarVentures/asn1-schema/pull/80

After some investigation, it seems that **EncryptedContent** usage is actually RFC-compliant. This [comment](https://github.com/PeculiarVentures/PKI.js/blob/master/src/EncryptedContentInfo.ts#L150) is most likely wrong. The confusion stems from an ambiguity between the following 2 formats (as they have the same serialization output):
- { context: 0, implicit: true ) + Constructed OctetString (with 1 chunk)
- { context: 0, implicit: false } + Primitive OctetString

This PR removes the non RFC-compliant EncryptedContent schema and adds minimal support to Constructed OctetStrings.

@microshine 