### PR TITLE
feat(schema): Add `APPLICATION` tags support

### DIFF
--- a/packages/schema/src/decorators.ts
+++ b/packages/schema/src/decorators.ts
@@ -19,6 +19,7 @@ export interface IAsn1PropOptions {
   optional?: boolean;
   defaultValue?: unknown;
   context?: number;
+  application?: number;
   implicit?: boolean;
   converter?: IAsnConverter;
   repeated?: AsnRepeatType;

--- a/packages/schema/src/serializer.ts
+++ b/packages/schema/src/serializer.ts
@@ -107,7 +107,47 @@ export class AsnSerializer {
               value: [asn1Item],
             }));
           }
-        } else if (schemaItem.repeated) {
+        }
+        else if (typeof schemaItem.application === "number") {
+          // APPLICATION
+          if (schemaItem.implicit) {
+            // IMPLICIT
+            if (!schemaItem.repeated
+              && (typeof schemaItem.type === "number" || isConvertible(schemaItem.type))) {
+              const value: { valueHex?: ArrayBuffer, value?: ArrayBuffer; } = {};
+              value.valueHex = asn1Item instanceof asn1js.Null ? asn1Item.valueBeforeDecodeView : asn1Item.valueBlock.toBER();
+              asn1Value.push(new asn1js.Primitive({
+                optional: schemaItem.optional,
+                idBlock: {
+                  tagClass: 2,
+                  tagNumber: schemaItem.application,
+                },
+                ...value,
+              }));
+            } else {
+              asn1Value.push(new asn1js.Constructed({
+                optional: schemaItem.optional,
+                idBlock: {
+                  tagClass: 2,
+                  tagNumber: schemaItem.application,
+                },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                value: (asn1Item as any).valueBlock.value,
+              }));
+            }
+          } else {
+            // EXPLICIT
+            asn1Value.push(new asn1js.Constructed({
+              optional: schemaItem.optional,
+              idBlock: {
+                tagClass: 2,
+                tagNumber: schemaItem.application,
+              },
+              value: [asn1Item],
+            }));
+          }
+        }
+        else if (schemaItem.repeated) {
           asn1Value = asn1Value.concat(asn1Item);
         } else {
           // UNIVERSAL

--- a/packages/schema/test/test.ts
+++ b/packages/schema/test/test.ts
@@ -521,6 +521,57 @@ context("Test", () => {
     });
   });
 
+  context("APPLICATION", ()  => {
+    context("IMPLICIT", () => {
+      class Test {
+        @src.AsnProp({
+          type: src.OctetString,
+          application: 33,
+          implicit: true,
+        })
+        public value = new src.OctetString();
+      }
+
+      it("serialize", () => {
+        const obj = new Test();
+        obj.value = new src.OctetString([1, 2, 3, 4, 5]);
+        const buf = src.AsnSerializer.serialize(obj);
+        console.log(Buffer.from(buf).toString("hex"))
+        assertBuffer(Buffer.from(buf), Buffer.from("30085f21050102030405", "hex"));
+      });
+
+      it("parse", () => {
+        const obj = src.AsnParser.parse(new Uint8Array(Buffer.from("30085f21050102030405", "hex")).buffer, Test);
+        assert.strictEqual(obj.value.byteLength, 5);
+      });
+    })
+
+    context("EXPLICIT", () => {
+
+      class Test {
+        @src.AsnProp({
+          type: src.AsnPropTypes.OctetString,
+          application: 152,
+        })
+        public value!: ArrayBuffer;
+      }
+
+      it("serialize", () => {
+        const obj = new Test();
+        obj.value = new Uint8Array([1, 2, 3, 4, 5]).buffer;
+        const buf = src.AsnSerializer.serialize(obj);
+        assertBuffer(Buffer.from(buf), Buffer.from("300b7f81180704050102030405", "hex"));
+      });
+
+      it("parse", () => {
+        const obj = src.AsnParser.parse(new Uint8Array(Buffer.from("300b7f81180704050102030405", "hex")).buffer, Test);
+        console.log(obj)
+        assert.strictEqual(obj.value.byteLength, 5);
+      });
+
+    });
+  })
+
   context("CONTEXT-SPECIFIC", () => {
 
     context("IMPLICIT", () => {


### PR DESCRIPTION
Added support for `APPLICATION` tags for parser and serializer

Implicit:
![image](https://github.com/user-attachments/assets/010e1426-809b-44c9-91a7-fccf1c1b5711)

Explicit:
![image](https://github.com/user-attachments/assets/b34bbe31-15e7-473b-83d0-f4a207f65881)

Example:
```ts
class Test {
  @AsnProp({
    type: OctetString,
    application: 33,
    implicit: true,
  })
  public value = new OctetString();
}
```