### PR TITLE
Add support for KeyMint v400

### DIFF
--- a/packages/android/README.md
+++ b/packages/android/README.md
@@ -13,9 +13,9 @@
 
 The `KeyDescription` class in this library represents the ASN.1 schema for the Android Keystore Key Description structure. However, in practice, there are cases where the `AuthorizationList` fields in the `softwareEnforced` and `teeEnforced` fields are not strictly ordered, which can lead to ASN.1 structure reading errors.
 
-Starting with version 400, the schema has been updated to use `keyMintVersion` instead of `keymasterVersion`, `keyMintSecurityLevel` instead of `keymasterSecurityLevel`, and `hardwareEnforced` instead of `teeEnforced`. To support this, we've added the `KeyMintKeyDescription` class.
+Starting with version 300, the schema has been updated to use `keyMintVersion` instead of `keymasterVersion`, `keyMintSecurityLevel` instead of `keymasterSecurityLevel`, and `hardwareEnforced` instead of `teeEnforced`. To support this, we've added the `KeyMint300KeyDescription` and `KeyMintKeyDescription` (v400) classes.
 
-To address the non-strict ordering issue, this library provides a `NonStandardKeyDescription` and `NonStandardKeyMintKeyDescription` classes that can read such structures. However, when creating extensions, it is recommended to use `KeyDescription` or `KeyMintKeyDescription`, as they guarantee the order of object fields according to the specification.
+To address the non-strict ordering issue, this library provides `NonStandardKeyDescription`, `NonStandardKeyMint300KeyDescription` and `NonStandardKeyMintKeyDescription` classes that can read such structures. However, when creating extensions, it is recommended to use `KeyDescription`, `KeyMint300KeyDescription` or `KeyMintKeyDescription`, as they guarantee the order of object fields according to the specification.
 
 Here are simplified TypeScript examples:
 
@@ -56,7 +56,32 @@ const keyDescription = new KeyDescription({
   }),
 });
 
-// KeyMint KeyDescription (v400)
+// KeyMint v300 KeyDescription
+const keyMint300Description = new KeyMint300KeyDescription({
+  attestationVersion: android.Version.keyMint3,
+  attestationSecurityLevel: android.SecurityLevel.software,
+  keyMintVersion: 1,
+  keyMintSecurityLevel: android.SecurityLevel.trustedEnvironment,
+  attestationChallenge: new OctetString(Buffer.from("challenge-data", "utf8")),
+  uniqueId: new OctetString(Buffer.from("unique-id-data", "utf8")),
+  softwareEnforced: new android.AuthorizationList({
+    creationDateTime: 1684321765000,
+  }),
+  hardwareEnforced: new android.AuthorizationList({
+    purpose: new android.IntegerSet([1, 2]),
+    algorithm: 3, // EC
+    keySize: 256,
+    attestationIdSecondImei: new OctetString(Buffer.from("second-imei", "utf8")),
+    rootOfTrust: new android.RootOfTrust({
+      verifiedBootKey: new OctetString(Buffer.from("boot-key-data", "utf8")),
+      deviceLocked: true,
+      verifiedBootState: android.VerifiedBootState.verified,
+      verifiedBootHash: new OctetString(Buffer.from("boot-hash-data", "utf8")), // Required in v300 and above
+    }),
+  }),
+});
+
+// KeyMint v400 KeyDescription
 const keyMintDescription = new KeyMintKeyDescription({
   attestationVersion: android.Version.keyMint4,
   attestationSecurityLevel: android.SecurityLevel.software,
@@ -66,72 +91,41 @@ const keyMintDescription = new KeyMintKeyDescription({
   uniqueId: new OctetString(Buffer.from("unique-id-data", "utf8")),
   softwareEnforced: new android.AuthorizationList({
     creationDateTime: 1684321765000,
-    attestationApplicationId: new OctetString(AsnConvert.serialize(attestation)),
   }),
   hardwareEnforced: new android.AuthorizationList({
     purpose: new android.IntegerSet([1, 2]),
     algorithm: 3, // EC
     keySize: 256,
-    digest: new android.IntegerSet([4]), // SHA-256
-    ecCurve: 1, // P-256
-    userAuthType: 2,
-    origin: 1,
-    // New v400 fields
     attestationIdSecondImei: new OctetString(Buffer.from("second-imei", "utf8")),
-    moduleHash: new OctetString(Buffer.from("module-hash-value", "utf8")),
+    moduleHash: new OctetString(Buffer.from("module-hash-value", "utf8")), // Available in v400
     rootOfTrust: new android.RootOfTrust({
       verifiedBootKey: new OctetString(Buffer.from("boot-key-data", "utf8")),
       deviceLocked: true,
       verifiedBootState: android.VerifiedBootState.verified,
-      verifiedBootHash: new OctetString(Buffer.from("boot-hash-data", "utf8")), // Required in v400
+      verifiedBootHash: new OctetString(Buffer.from("boot-hash-data", "utf8")),
     }),
   }),
 });
 
 const raw = AsnConvert.serialize(keyDescription);
-const rawKeyMint = AsnConvert.serialize(keyMintDescription);
+const rawKeyMint300 = AsnConvert.serialize(keyMint300Description);
+const rawKeyMint400 = AsnConvert.serialize(keyMintDescription);
 ```
 
-Example of reading a `NonStandardKeyDescription` object in TypeScript
+Example of reading a non-standard KeyDescription:
 
 ```typescript
+// Parse with appropriate class based on version
 const keyDescription = AsnConvert.parse(raw, NonStandardKeyDescription);
+const keyMint300Description = AsnConvert.parse(rawKeyMint300, NonStandardKeyMint300KeyDescription);
+const keyMint400Description = AsnConvert.parse(rawKeyMint400, NonStandardKeyMintKeyDescription);
 
-console.log(keyDescription.attestationVersion); // 200
-console.log(keyDescription.attestationSecurityLevel); // 0 (software)
-console.log(keyDescription.keymasterVersion); // 1
-console.log(keyDescription.keymasterSecurityLevel); // 0 (software)
-console.log(keyDescription.attestationChallenge.byteLength); // 3
-console.log(keyDescription.uniqueId.byteLength); // 3
-console.log(keyDescription.softwareEnforced.findProperty("attestationApplicationId")?.byteLength); // length varies
-console.log(keyDescription.teeEnforced.findProperty("purpose")?.length); // 1
+// All versions support both old and new property names
+console.log(keyMint300Description.keyMintVersion); // 1
+console.log(keyMint300Description.keymasterVersion); // Same as keyMintVersion (1)
+console.log(keyMint300Description.hardwareEnforced === keyMint300Description.teeEnforced); // true
 
-// Can also use KeyMint naming convention with NonStandardKeyDescription
-console.log(keyDescription.keyMintVersion); // 1 (same as keymasterVersion)
-console.log(keyDescription.hardwareEnforced === keyDescription.teeEnforced); // true
-```
-
-Example of reading a v400 KeyMint description:
-
-```typescript
-const keyMintDescription = AsnConvert.parse(rawKeyMint, NonStandardKeyMintKeyDescription);
-
-console.log(keyMintDescription.attestationVersion); // 400
-console.log(keyMintDescription.keyMintVersion); // 1
-console.log(keyMintDescription.keyMintSecurityLevel); // 1 (trustedEnvironment)
-
-// Access the new v400 fields
-const moduleHash = keyMintDescription.hardwareEnforced.findProperty("moduleHash");
-console.log(moduleHash && Buffer.from(moduleHash).toString("utf8")); // "module-hash-value"
-
-const secondImei = keyMintDescription.hardwareEnforced.findProperty("attestationIdSecondImei");
-console.log(secondImei && Buffer.from(secondImei).toString("utf8")); // "second-imei"
-
-// Converting between legacy and v400 KeyDescriptions
-const legacyDesc = keyMintDescription.toLegacyKeyDescription();
-console.log(legacyDesc.keymasterVersion === keyMintDescription.keyMintVersion); // true
-console.log(legacyDesc.teeEnforced === keyMintDescription.hardwareEnforced); // true
-
-const backToKeyMint = KeyMintKeyDescription.fromLegacyKeyDescription(legacyDesc);
-console.log(backToKeyMint.keyMintVersion === legacyDesc.keymasterVersion); // true
+// Converting between versions
+const legacyFromV300 = keyMint300Description.toLegacyKeyDescription();
+const v400FromLegacy = KeyMintKeyDescription.fromLegacyKeyDescription(legacyFromV300);
 ```

--- a/packages/android/README.md
+++ b/packages/android/README.md
@@ -13,7 +13,9 @@
 
 The `KeyDescription` class in this library represents the ASN.1 schema for the Android Keystore Key Description structure. However, in practice, there are cases where the `AuthorizationList` fields in the `softwareEnforced` and `teeEnforced` fields are not strictly ordered, which can lead to ASN.1 structure reading errors.
 
-To address this issue, this library provides a `NonStandardKeyDescription` class that can read such structures. However, when creating extensions, it is recommended to use `KeyDescription`, as it guarantees the order of object fields according to the specification.
+Starting with version 400, the schema has been updated to use `keyMintVersion` instead of `keymasterVersion`, `keyMintSecurityLevel` instead of `keymasterSecurityLevel`, and `hardwareEnforced` instead of `teeEnforced`. To support this, we've added the `KeyMintKeyDescription` class.
+
+To address the non-strict ordering issue, this library provides a `NonStandardKeyDescription` and `NonStandardKeyMintKeyDescription` classes that can read such structures. However, when creating extensions, it is recommended to use `KeyDescription` or `KeyMintKeyDescription`, as they guarantee the order of object fields according to the specification.
 
 Here are simplified TypeScript examples:
 
@@ -27,13 +29,12 @@ const attestation = new android.AttestationApplicationId({
       version: 1,
     }),
   ],
-  signatureDigests: [
-    new OctetString(Buffer.from("123", "utf8")),
-  ],
+  signatureDigests: [new OctetString(Buffer.from("123", "utf8"))],
 });
 
+// Legacy KeyDescription
 const keyDescription = new KeyDescription({
-  attestationVersion: android.Version.v200,
+  attestationVersion: android.Version.keyMint2,
   attestationSecurityLevel: android.SecurityLevel.software,
   keymasterVersion: 1,
   keymasterSecurityLevel: android.SecurityLevel.software,
@@ -55,7 +56,40 @@ const keyDescription = new KeyDescription({
   }),
 });
 
+// KeyMint KeyDescription (v400)
+const keyMintDescription = new KeyMintKeyDescription({
+  attestationVersion: android.Version.keyMint4,
+  attestationSecurityLevel: android.SecurityLevel.software,
+  keyMintVersion: 1,
+  keyMintSecurityLevel: android.SecurityLevel.trustedEnvironment,
+  attestationChallenge: new OctetString(Buffer.from("challenge-data", "utf8")),
+  uniqueId: new OctetString(Buffer.from("unique-id-data", "utf8")),
+  softwareEnforced: new android.AuthorizationList({
+    creationDateTime: 1684321765000,
+    attestationApplicationId: new OctetString(AsnConvert.serialize(attestation)),
+  }),
+  hardwareEnforced: new android.AuthorizationList({
+    purpose: new android.IntegerSet([1, 2]),
+    algorithm: 3, // EC
+    keySize: 256,
+    digest: new android.IntegerSet([4]), // SHA-256
+    ecCurve: 1, // P-256
+    userAuthType: 2,
+    origin: 1,
+    // New v400 fields
+    attestationIdSecondImei: new OctetString(Buffer.from("second-imei", "utf8")),
+    moduleHash: new OctetString(Buffer.from("module-hash-value", "utf8")),
+    rootOfTrust: new android.RootOfTrust({
+      verifiedBootKey: new OctetString(Buffer.from("boot-key-data", "utf8")),
+      deviceLocked: true,
+      verifiedBootState: android.VerifiedBootState.verified,
+      verifiedBootHash: new OctetString(Buffer.from("boot-hash-data", "utf8")), // Required in v400
+    }),
+  }),
+});
+
 const raw = AsnConvert.serialize(keyDescription);
+const rawKeyMint = AsnConvert.serialize(keyMintDescription);
 ```
 
 Example of reading a `NonStandardKeyDescription` object in TypeScript
@@ -63,12 +97,41 @@ Example of reading a `NonStandardKeyDescription` object in TypeScript
 ```typescript
 const keyDescription = AsnConvert.parse(raw, NonStandardKeyDescription);
 
-console.log(keyDescription.attestationVersion); // 100
-console.log(keyDescription.attestationSecurityLevel); // 1
-console.log(keyDescription.keymasterVersion); // 100
-console.log(keyDescription.keymasterSecurityLevel); // 1
-console.log(keyDescription.attestationChallenge.byteLength); // 32
-console.log(keyDescription.uniqueId.byteLength); // 0
-console.log(keyDescription.softwareEnforced.findProperty("attestationApplicationId")?.byteLength); // 81
-console.log(keyDescription.teeEnforced.findProperty("attestationIdBrand")?.byteLength); // 8
+console.log(keyDescription.attestationVersion); // 200
+console.log(keyDescription.attestationSecurityLevel); // 0 (software)
+console.log(keyDescription.keymasterVersion); // 1
+console.log(keyDescription.keymasterSecurityLevel); // 0 (software)
+console.log(keyDescription.attestationChallenge.byteLength); // 3
+console.log(keyDescription.uniqueId.byteLength); // 3
+console.log(keyDescription.softwareEnforced.findProperty("attestationApplicationId")?.byteLength); // length varies
+console.log(keyDescription.teeEnforced.findProperty("purpose")?.length); // 1
+
+// Can also use KeyMint naming convention with NonStandardKeyDescription
+console.log(keyDescription.keyMintVersion); // 1 (same as keymasterVersion)
+console.log(keyDescription.hardwareEnforced === keyDescription.teeEnforced); // true
+```
+
+Example of reading a v400 KeyMint description:
+
+```typescript
+const keyMintDescription = AsnConvert.parse(rawKeyMint, NonStandardKeyMintKeyDescription);
+
+console.log(keyMintDescription.attestationVersion); // 400
+console.log(keyMintDescription.keyMintVersion); // 1
+console.log(keyMintDescription.keyMintSecurityLevel); // 1 (trustedEnvironment)
+
+// Access the new v400 fields
+const moduleHash = keyMintDescription.hardwareEnforced.findProperty("moduleHash");
+console.log(moduleHash && Buffer.from(moduleHash).toString("utf8")); // "module-hash-value"
+
+const secondImei = keyMintDescription.hardwareEnforced.findProperty("attestationIdSecondImei");
+console.log(secondImei && Buffer.from(secondImei).toString("utf8")); // "second-imei"
+
+// Converting between legacy and v400 KeyDescriptions
+const legacyDesc = keyMintDescription.toLegacyKeyDescription();
+console.log(legacyDesc.keymasterVersion === keyMintDescription.keyMintVersion); // true
+console.log(legacyDesc.teeEnforced === keyMintDescription.hardwareEnforced); // true
+
+const backToKeyMint = KeyMintKeyDescription.fromLegacyKeyDescription(legacyDesc);
+console.log(backToKeyMint.keyMintVersion === legacyDesc.keymasterVersion); // true
 ```

--- a/packages/android/src/key_description.ts
+++ b/packages/android/src/key_description.ts
@@ -346,11 +346,11 @@ export class KeyDescription {
 }
 
 /**
- * Implements ASN.1 structure for KeyMint key description (v400).
+ * Implements ASN.1 structure for KeyMint key description (v300 and v400).
  *
  * ```asn
  * KeyDescription ::= SEQUENCE {
- *   attestationVersion         INTEGER, # version 400
+ *   attestationVersion         INTEGER, # versions 300 and 400
  *   attestationSecurityLevel   SecurityLevel,
  *   keyMintVersion             INTEGER,
  *   keyMintSecurityLevel       SecurityLevel,
@@ -411,84 +411,6 @@ export class KeyMintKeyDescription {
    */
   public static fromLegacyKeyDescription(keyDesc: KeyDescription): KeyMintKeyDescription {
     return new KeyMintKeyDescription({
-      attestationVersion: keyDesc.attestationVersion,
-      attestationSecurityLevel: keyDesc.attestationSecurityLevel,
-      keyMintVersion: keyDesc.keymasterVersion,
-      keyMintSecurityLevel: keyDesc.keymasterSecurityLevel,
-      attestationChallenge: keyDesc.attestationChallenge,
-      uniqueId: keyDesc.uniqueId,
-      softwareEnforced: keyDesc.softwareEnforced,
-      hardwareEnforced: keyDesc.teeEnforced,
-    });
-  }
-}
-
-/**
- * Implements ASN.1 structure for KeyMint key description (v300).
- *
- * ```asn
- * KeyDescription ::= SEQUENCE {
- *   attestationVersion         INTEGER, # version 300
- *   attestationSecurityLevel   SecurityLevel,
- *   keyMintVersion             INTEGER,
- *   keyMintSecurityLevel       SecurityLevel,
- *   attestationChallenge       OCTET_STRING,
- *   uniqueId                   OCTET_STRING,
- *   softwareEnforced           AuthorizationList,
- *   hardwareEnforced           AuthorizationList,
- * }
- * ```
- */
-export class KeyMint300KeyDescription {
-  @AsnProp({ type: AsnPropTypes.Integer })
-  public attestationVersion: number | Version = Version.keyMint3;
-
-  @AsnProp({ type: AsnPropTypes.Enumerated })
-  public attestationSecurityLevel: SecurityLevel = SecurityLevel.software;
-
-  @AsnProp({ type: AsnPropTypes.Integer })
-  public keyMintVersion = 0;
-
-  @AsnProp({ type: AsnPropTypes.Enumerated })
-  public keyMintSecurityLevel: SecurityLevel = SecurityLevel.software;
-
-  @AsnProp({ type: OctetString })
-  public attestationChallenge = new OctetString();
-
-  @AsnProp({ type: OctetString })
-  public uniqueId = new OctetString();
-
-  @AsnProp({ type: AuthorizationList })
-  public softwareEnforced = new AuthorizationList();
-
-  @AsnProp({ type: AuthorizationList })
-  public hardwareEnforced = new AuthorizationList();
-
-  public constructor(params: Partial<KeyMint300KeyDescription> = {}) {
-    Object.assign(this, params);
-  }
-
-  /**
-   * Convert to legacy KeyDescription for backwards compatibility
-   */
-  public toLegacyKeyDescription(): KeyDescription {
-    return new KeyDescription({
-      attestationVersion: this.attestationVersion,
-      attestationSecurityLevel: this.attestationSecurityLevel,
-      keymasterVersion: this.keyMintVersion,
-      keymasterSecurityLevel: this.keyMintSecurityLevel,
-      attestationChallenge: this.attestationChallenge,
-      uniqueId: this.uniqueId,
-      softwareEnforced: this.softwareEnforced,
-      teeEnforced: this.hardwareEnforced,
-    });
-  }
-
-  /**
-   * Create from legacy KeyDescription for backwards compatibility
-   */
-  public static fromLegacyKeyDescription(keyDesc: KeyDescription): KeyMint300KeyDescription {
-    return new KeyMint300KeyDescription({
       attestationVersion: keyDesc.attestationVersion,
       attestationSecurityLevel: keyDesc.attestationSecurityLevel,
       keyMintVersion: keyDesc.keymasterVersion,

--- a/packages/android/src/key_description.ts
+++ b/packages/android/src/key_description.ts
@@ -295,7 +295,8 @@ export enum Version {
   KM4_1 = 4,
   keyMint1 = 100,
   keyMint2 = 200,
-  keyMint4 = 400, // Added new version 400
+  keyMint3 = 300,
+  keyMint4 = 400,
 }
 
 /**
@@ -410,6 +411,84 @@ export class KeyMintKeyDescription {
    */
   public static fromLegacyKeyDescription(keyDesc: KeyDescription): KeyMintKeyDescription {
     return new KeyMintKeyDescription({
+      attestationVersion: keyDesc.attestationVersion,
+      attestationSecurityLevel: keyDesc.attestationSecurityLevel,
+      keyMintVersion: keyDesc.keymasterVersion,
+      keyMintSecurityLevel: keyDesc.keymasterSecurityLevel,
+      attestationChallenge: keyDesc.attestationChallenge,
+      uniqueId: keyDesc.uniqueId,
+      softwareEnforced: keyDesc.softwareEnforced,
+      hardwareEnforced: keyDesc.teeEnforced,
+    });
+  }
+}
+
+/**
+ * Implements ASN.1 structure for KeyMint key description (v300).
+ *
+ * ```asn
+ * KeyDescription ::= SEQUENCE {
+ *   attestationVersion         INTEGER, # version 300
+ *   attestationSecurityLevel   SecurityLevel,
+ *   keyMintVersion             INTEGER,
+ *   keyMintSecurityLevel       SecurityLevel,
+ *   attestationChallenge       OCTET_STRING,
+ *   uniqueId                   OCTET_STRING,
+ *   softwareEnforced           AuthorizationList,
+ *   hardwareEnforced           AuthorizationList,
+ * }
+ * ```
+ */
+export class KeyMint300KeyDescription {
+  @AsnProp({ type: AsnPropTypes.Integer })
+  public attestationVersion: number | Version = Version.keyMint3;
+
+  @AsnProp({ type: AsnPropTypes.Enumerated })
+  public attestationSecurityLevel: SecurityLevel = SecurityLevel.software;
+
+  @AsnProp({ type: AsnPropTypes.Integer })
+  public keyMintVersion = 0;
+
+  @AsnProp({ type: AsnPropTypes.Enumerated })
+  public keyMintSecurityLevel: SecurityLevel = SecurityLevel.software;
+
+  @AsnProp({ type: OctetString })
+  public attestationChallenge = new OctetString();
+
+  @AsnProp({ type: OctetString })
+  public uniqueId = new OctetString();
+
+  @AsnProp({ type: AuthorizationList })
+  public softwareEnforced = new AuthorizationList();
+
+  @AsnProp({ type: AuthorizationList })
+  public hardwareEnforced = new AuthorizationList();
+
+  public constructor(params: Partial<KeyMint300KeyDescription> = {}) {
+    Object.assign(this, params);
+  }
+
+  /**
+   * Convert to legacy KeyDescription for backwards compatibility
+   */
+  public toLegacyKeyDescription(): KeyDescription {
+    return new KeyDescription({
+      attestationVersion: this.attestationVersion,
+      attestationSecurityLevel: this.attestationSecurityLevel,
+      keymasterVersion: this.keyMintVersion,
+      keymasterSecurityLevel: this.keyMintSecurityLevel,
+      attestationChallenge: this.attestationChallenge,
+      uniqueId: this.uniqueId,
+      softwareEnforced: this.softwareEnforced,
+      teeEnforced: this.hardwareEnforced,
+    });
+  }
+
+  /**
+   * Create from legacy KeyDescription for backwards compatibility
+   */
+  public static fromLegacyKeyDescription(keyDesc: KeyDescription): KeyMint300KeyDescription {
+    return new KeyMint300KeyDescription({
       attestationVersion: keyDesc.attestationVersion,
       attestationSecurityLevel: keyDesc.attestationSecurityLevel,
       keyMintVersion: keyDesc.keymasterVersion,

--- a/packages/android/src/nonstandard.ts
+++ b/packages/android/src/nonstandard.ts
@@ -69,7 +69,7 @@ export class NonStandardAuthorizationList extends AsnArray<NonStandardAuthorizat
  *
  * ```asn
  * KeyDescription ::= SEQUENCE {
- *   attestationVersion         INTEGER, # versions 1, 2, 3, 4, 100, 200, and 400
+ *   attestationVersion         INTEGER, # versions 1, 2, 3, 4, 100, 200, 300, and 400
  *   attestationSecurityLevel   SecurityLevel,
  *   keymasterVersion/keyMintVersion INTEGER,
  *   keymasterSecurityLevel/keyMintSecurityLevel SecurityLevel,

--- a/packages/android/src/nonstandard.ts
+++ b/packages/android/src/nonstandard.ts
@@ -159,3 +159,27 @@ export class NonStandardKeyMintKeyDescription extends NonStandardKeyDescription 
     super(params);
   }
 }
+
+/**
+ * New class for v300 Keymint non-standard key description.
+ * This uses the same underlying structure as NonStandardKeyDescription,
+ * but with renamed properties to match the updated specification.
+ */
+@AsnType({ type: AsnTypeTypes.Sequence })
+export class NonStandardKeyMint300KeyDescription extends NonStandardKeyDescription {
+  // Override constructor to use the correct property names
+  public constructor(params: Partial<NonStandardKeyDescription> = {}) {
+    // Translate between old and new property names if needed
+    if ("keymasterVersion" in params && !("keyMintVersion" in params)) {
+      params.keyMintVersion = params.keymasterVersion;
+    }
+    if ("keymasterSecurityLevel" in params && !("keyMintSecurityLevel" in params)) {
+      params.keyMintSecurityLevel = params.keymasterSecurityLevel;
+    }
+    if ("teeEnforced" in params && !("hardwareEnforced" in params)) {
+      params.hardwareEnforced = params.teeEnforced;
+    }
+
+    super(params);
+  }
+}

--- a/packages/android/src/nonstandard.ts
+++ b/packages/android/src/nonstandard.ts
@@ -137,36 +137,12 @@ export class NonStandardKeyDescription {
 }
 
 /**
- * New class for v400 Keymint non-standard key description.
+ * New class for v300 and v400 KeyMint non-standard key description.
  * This uses the same underlying structure as NonStandardKeyDescription,
  * but with renamed properties to match the updated specification.
  */
 @AsnType({ type: AsnTypeTypes.Sequence })
 export class NonStandardKeyMintKeyDescription extends NonStandardKeyDescription {
-  // Override constructor to use the correct property names
-  public constructor(params: Partial<NonStandardKeyDescription> = {}) {
-    // Translate between old and new property names if needed
-    if ("keymasterVersion" in params && !("keyMintVersion" in params)) {
-      params.keyMintVersion = params.keymasterVersion;
-    }
-    if ("keymasterSecurityLevel" in params && !("keyMintSecurityLevel" in params)) {
-      params.keyMintSecurityLevel = params.keymasterSecurityLevel;
-    }
-    if ("teeEnforced" in params && !("hardwareEnforced" in params)) {
-      params.hardwareEnforced = params.teeEnforced;
-    }
-
-    super(params);
-  }
-}
-
-/**
- * New class for v300 Keymint non-standard key description.
- * This uses the same underlying structure as NonStandardKeyDescription,
- * but with renamed properties to match the updated specification.
- */
-@AsnType({ type: AsnTypeTypes.Sequence })
-export class NonStandardKeyMint300KeyDescription extends NonStandardKeyDescription {
   // Override constructor to use the correct property names
   public constructor(params: Partial<NonStandardKeyDescription> = {}) {
     // Translate between old and new property names if needed

--- a/packages/android/test/test.ts
+++ b/packages/android/test/test.ts
@@ -1,6 +1,7 @@
 import * as assert from "node:assert";
 import { AsnConvert, OctetString } from "@peculiar/asn1-schema";
 import * as android from "@peculiar/asn1-android";
+import { Convert } from "pvtsutils";
 
 describe("Android", () => {
   describe("KeyDescription", () => {
@@ -113,6 +114,187 @@ describe("Android", () => {
       assert.strictEqual(attestation2.packageInfos[0].version, 1);
       assert.strictEqual(attestation2.signatureDigests.length, 1);
       assert.strictEqual(attestation2.signatureDigests[0].byteLength, 3);
+    });
+  });
+
+  // https://github.com/PeculiarVentures/asn1-schema/issues/107
+  describe("KeyMint v400", () => {
+    it("should create and serialize KeyMintKeyDescription", () => {
+      const attestation = new android.AttestationApplicationId({
+        packageInfos: [
+          new android.AttestationPackageInfo({
+            packageName: new OctetString(Buffer.from("com.example.app", "utf8")),
+            version: 1,
+          }),
+        ],
+        signatureDigests: [new OctetString(Buffer.from("0123456789abcdef", "hex"))],
+      });
+
+      const keyMintDesc = new android.KeyMintKeyDescription({
+        attestationVersion: android.Version.keyMint4,
+        attestationSecurityLevel: android.SecurityLevel.software,
+        keyMintVersion: 1,
+        keyMintSecurityLevel: android.SecurityLevel.trustedEnvironment,
+        attestationChallenge: new OctetString(Buffer.from("challenge-data", "utf8")),
+        uniqueId: new OctetString(Buffer.from("unique-id-data", "utf8")),
+        softwareEnforced: new android.AuthorizationList({
+          creationDateTime: 1684321765000, // May 17, 2023
+          attestationApplicationId: new OctetString(AsnConvert.serialize(attestation)),
+        }),
+        hardwareEnforced: new android.AuthorizationList({
+          purpose: new android.IntegerSet([1, 2]),
+          algorithm: 3, // EC
+          keySize: 256,
+          digest: new android.IntegerSet([4]), // SHA-256
+          ecCurve: 1, // P-256
+          userAuthType: 2,
+          origin: 1,
+          attestationIdSecondImei: new OctetString(Buffer.from("second-imei", "utf8")),
+          moduleHash: new OctetString(Buffer.from("module-hash-value", "utf8")),
+          rootOfTrust: new android.RootOfTrust({
+            verifiedBootKey: new OctetString(Buffer.from("boot-key-data", "utf8")),
+            deviceLocked: true,
+            verifiedBootState: android.VerifiedBootState.verified,
+            verifiedBootHash: new OctetString(Buffer.from("boot-hash-data", "utf8")), // Required in v400
+          }),
+        }),
+      });
+
+      const raw = AsnConvert.serialize(keyMintDesc);
+      assert.ok(raw);
+      assert.ok(raw.byteLength > 0);
+
+      // Verify we can parse it back
+      const parsed = AsnConvert.parse(raw, android.KeyMintKeyDescription);
+      assert.strictEqual(parsed.attestationVersion, android.Version.keyMint4);
+      assert.strictEqual(parsed.keyMintVersion, 1);
+      assert.strictEqual(parsed.keyMintSecurityLevel, android.SecurityLevel.trustedEnvironment);
+      assert.ok(parsed.hardwareEnforced.moduleHash);
+      assert.strictEqual(
+        Convert.ToUtf8String(parsed.hardwareEnforced.moduleHash),
+        "module-hash-value",
+      );
+      assert.ok(parsed.hardwareEnforced.attestationIdSecondImei);
+      assert.strictEqual(
+        Convert.ToUtf8String(parsed.hardwareEnforced.attestationIdSecondImei),
+        "second-imei",
+      );
+
+      // Check RootOfTrust's verifiedBootHash
+      assert.ok(parsed.hardwareEnforced.rootOfTrust);
+      assert.ok(parsed.hardwareEnforced.rootOfTrust.verifiedBootHash);
+      assert.strictEqual(
+        Convert.ToUtf8String(parsed.hardwareEnforced.rootOfTrust.verifiedBootHash),
+        "boot-hash-data",
+      );
+    });
+
+    it("should parse v400 with NonStandardKeyMintKeyDescription", () => {
+      const keyMintDesc = new android.KeyMintKeyDescription({
+        attestationVersion: android.Version.keyMint4,
+        attestationSecurityLevel: android.SecurityLevel.software,
+        keyMintVersion: 1,
+        keyMintSecurityLevel: android.SecurityLevel.trustedEnvironment,
+        attestationChallenge: new OctetString(Buffer.from("challenge-data", "utf8")),
+        uniqueId: new OctetString(Buffer.from("unique-id-data", "utf8")),
+        softwareEnforced: new android.AuthorizationList({
+          creationDateTime: 1684321765000,
+        }),
+        hardwareEnforced: new android.AuthorizationList({
+          purpose: new android.IntegerSet([1, 2]),
+          algorithm: 3,
+          attestationIdSecondImei: new OctetString(Buffer.from("second-imei", "utf8")),
+          moduleHash: new OctetString(Buffer.from("module-hash-value", "utf8")),
+        }),
+      });
+
+      const raw = AsnConvert.serialize(keyMintDesc);
+
+      // Parse with non-standard parser
+      const parsed = AsnConvert.parse(raw, android.NonStandardKeyMintKeyDescription);
+
+      // Verify fields
+      assert.strictEqual(parsed.attestationVersion, android.Version.keyMint4);
+      assert.strictEqual(parsed.keyMintVersion, 1);
+      assert.strictEqual(parsed.keyMintSecurityLevel, android.SecurityLevel.trustedEnvironment);
+
+      // Check the new fields using the findProperty method
+      const moduleHash = parsed.hardwareEnforced.findProperty("moduleHash");
+      assert.ok(moduleHash);
+      assert.strictEqual(Convert.ToUtf8String(moduleHash), "module-hash-value");
+
+      const secondImei = parsed.hardwareEnforced.findProperty("attestationIdSecondImei");
+      assert.ok(secondImei);
+      assert.strictEqual(Convert.ToUtf8String(secondImei), "second-imei");
+    });
+
+    it("should convert between KeyDescription and KeyMintKeyDescription", () => {
+      // Create a legacy KeyDescription
+      const legacy = new android.KeyDescription({
+        attestationVersion: android.Version.KM4,
+        attestationSecurityLevel: android.SecurityLevel.software,
+        keymasterVersion: 1,
+        keymasterSecurityLevel: android.SecurityLevel.trustedEnvironment,
+        attestationChallenge: new OctetString(Buffer.from("challenge", "utf8")),
+        uniqueId: new OctetString(Buffer.from("uniqueid", "utf8")),
+        softwareEnforced: new android.AuthorizationList({
+          creationDateTime: 1506793476000,
+        }),
+        teeEnforced: new android.AuthorizationList({
+          purpose: new android.IntegerSet([1, 2]),
+          algorithm: 1,
+          keySize: 2048,
+        }),
+      });
+
+      // Convert to KeyMintKeyDescription
+      const keyMint = android.KeyMintKeyDescription.fromLegacyKeyDescription(legacy);
+
+      // Verify conversion
+      assert.strictEqual(keyMint.attestationVersion, legacy.attestationVersion);
+      assert.strictEqual(keyMint.keyMintVersion, legacy.keymasterVersion);
+      assert.strictEqual(keyMint.keyMintSecurityLevel, legacy.keymasterSecurityLevel);
+      assert.deepStrictEqual(keyMint.hardwareEnforced, legacy.teeEnforced);
+
+      // Convert back to legacy
+      const convertedBack = keyMint.toLegacyKeyDescription();
+
+      // Verify conversion back
+      assert.strictEqual(convertedBack.attestationVersion, legacy.attestationVersion);
+      assert.strictEqual(convertedBack.keymasterVersion, legacy.keymasterVersion);
+      assert.strictEqual(convertedBack.keymasterSecurityLevel, legacy.keymasterSecurityLevel);
+      assert.deepStrictEqual(convertedBack.teeEnforced, legacy.teeEnforced);
+    });
+
+    it("should access v400 fields via original NonStandardKeyDescription", () => {
+      // Create KeyMintKeyDescription
+      const keyMintDesc = new android.KeyMintKeyDescription({
+        attestationVersion: android.Version.keyMint4,
+        keyMintVersion: 1,
+        keyMintSecurityLevel: android.SecurityLevel.trustedEnvironment,
+        hardwareEnforced: new android.AuthorizationList({
+          moduleHash: new OctetString(Buffer.from("module-hash", "utf8")),
+          attestationIdSecondImei: new OctetString(Buffer.from("second-imei", "utf8")),
+        }),
+      });
+
+      const raw = AsnConvert.serialize(keyMintDesc);
+
+      // Parse with original NonStandardKeyDescription
+      const parsed = AsnConvert.parse(raw, android.NonStandardKeyDescription);
+
+      // Should access v400 fields via accessors
+      assert.strictEqual(parsed.keyMintVersion, 1);
+      assert.strictEqual(parsed.keyMintSecurityLevel, android.SecurityLevel.trustedEnvironment);
+
+      // Check module hash and second IMEI with hardwareEnforced getter
+      const moduleHash = parsed.hardwareEnforced.findProperty("moduleHash");
+      assert.ok(moduleHash);
+      assert.strictEqual(Convert.ToUtf8String(moduleHash), "module-hash");
+
+      const secondImei = parsed.hardwareEnforced.findProperty("attestationIdSecondImei");
+      assert.ok(secondImei);
+      assert.strictEqual(Convert.ToUtf8String(secondImei), "second-imei");
     });
   });
 });


### PR DESCRIPTION
Introduce KeyMint v400 properties and methods while maintaining backward compatibility with previous versions. Update relevant classes and structures to reflect the new specification.