### PR TITLE
Add FIPS 204 ML-DSA and FIPS 205 SLH-DSA object identifiers

### DIFF
--- a/packages/x509-post-quantum/src/index.ts
+++ b/packages/x509-post-quantum/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./composite_signatures";
 export * from "./composite_keys";
+export * from "./object_identifiers";

--- a/packages/x509-post-quantum/src/object_identifiers.ts
+++ b/packages/x509-post-quantum/src/object_identifiers.ts
@@ -1,0 +1,133 @@
+/**
+ * Object identifiers for NIST FIPS 204 (ML-DSA) and FIPS 205 (SLH-DSA)
+ * pure signature algorithms, registered in the NIST Computer Security
+ * Objects Register (CSOR).
+ *
+ * Per FIPS 204 §5, FIPS 205 §9, and NIST CSOR, the AlgorithmIdentifier
+ * for pure ML-DSA and SLH-DSA does NOT carry parameters (the parameters
+ * field is ABSENT, not NULL) — the same encoding convention used by
+ * Ed25519 (RFC 8410).
+ *
+ * References:
+ *   FIPS 204: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf
+ *   FIPS 205: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf
+ *   NIST CSOR: https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration
+ */
+
+/**
+ * ```asn1
+ * sigAlgs OBJECT IDENTIFIER ::= {
+ *   joint-iso-itu-t(2) country(16) us(840) organization(1) gov(101)
+ *   csor(3) nistAlgorithm(4) 3 }
+ * ```
+ */
+const id_sigAlgs = "2.16.840.1.101.3.4.3";
+
+// ----- FIPS 204 — ML-DSA (pure) -----
+
+/**
+ * ```asn1
+ * id-ml-dsa-44 OBJECT IDENTIFIER ::= { sigAlgs 17 }
+ * ```
+ */
+export const id_ml_dsa_44 = `${id_sigAlgs}.17`;
+
+/**
+ * ```asn1
+ * id-ml-dsa-65 OBJECT IDENTIFIER ::= { sigAlgs 18 }
+ * ```
+ */
+export const id_ml_dsa_65 = `${id_sigAlgs}.18`;
+
+/**
+ * ```asn1
+ * id-ml-dsa-87 OBJECT IDENTIFIER ::= { sigAlgs 19 }
+ * ```
+ */
+export const id_ml_dsa_87 = `${id_sigAlgs}.19`;
+
+// ----- FIPS 205 — SLH-DSA (pure) -----
+
+/**
+ * ```asn1
+ * id-slh-dsa-sha2-128s OBJECT IDENTIFIER ::= { sigAlgs 20 }
+ * ```
+ */
+export const id_slh_dsa_sha2_128s = `${id_sigAlgs}.20`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-sha2-128f OBJECT IDENTIFIER ::= { sigAlgs 21 }
+ * ```
+ */
+export const id_slh_dsa_sha2_128f = `${id_sigAlgs}.21`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-sha2-192s OBJECT IDENTIFIER ::= { sigAlgs 22 }
+ * ```
+ */
+export const id_slh_dsa_sha2_192s = `${id_sigAlgs}.22`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-sha2-192f OBJECT IDENTIFIER ::= { sigAlgs 23 }
+ * ```
+ */
+export const id_slh_dsa_sha2_192f = `${id_sigAlgs}.23`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-sha2-256s OBJECT IDENTIFIER ::= { sigAlgs 24 }
+ * ```
+ */
+export const id_slh_dsa_sha2_256s = `${id_sigAlgs}.24`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-sha2-256f OBJECT IDENTIFIER ::= { sigAlgs 25 }
+ * ```
+ */
+export const id_slh_dsa_sha2_256f = `${id_sigAlgs}.25`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-shake-128s OBJECT IDENTIFIER ::= { sigAlgs 26 }
+ * ```
+ */
+export const id_slh_dsa_shake_128s = `${id_sigAlgs}.26`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-shake-128f OBJECT IDENTIFIER ::= { sigAlgs 27 }
+ * ```
+ */
+export const id_slh_dsa_shake_128f = `${id_sigAlgs}.27`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-shake-192s OBJECT IDENTIFIER ::= { sigAlgs 28 }
+ * ```
+ */
+export const id_slh_dsa_shake_192s = `${id_sigAlgs}.28`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-shake-192f OBJECT IDENTIFIER ::= { sigAlgs 29 }
+ * ```
+ */
+export const id_slh_dsa_shake_192f = `${id_sigAlgs}.29`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-shake-256s OBJECT IDENTIFIER ::= { sigAlgs 30 }
+ * ```
+ */
+export const id_slh_dsa_shake_256s = `${id_sigAlgs}.30`;
+
+/**
+ * ```asn1
+ * id-slh-dsa-shake-256f OBJECT IDENTIFIER ::= { sigAlgs 31 }
+ * ```
+ */
+export const id_slh_dsa_shake_256f = `${id_sigAlgs}.31`;

--- a/packages/x509-post-quantum/test/test.sepc.ts
+++ b/packages/x509-post-quantum/test/test.sepc.ts
@@ -8,6 +8,21 @@ import {
   CompositeSignatureValue,
   id_alg_composite,
   id_composite_key,
+  id_ml_dsa_44,
+  id_ml_dsa_65,
+  id_ml_dsa_87,
+  id_slh_dsa_sha2_128s,
+  id_slh_dsa_sha2_128f,
+  id_slh_dsa_sha2_192s,
+  id_slh_dsa_sha2_192f,
+  id_slh_dsa_sha2_256s,
+  id_slh_dsa_sha2_256f,
+  id_slh_dsa_shake_128s,
+  id_slh_dsa_shake_128f,
+  id_slh_dsa_shake_192s,
+  id_slh_dsa_shake_192f,
+  id_slh_dsa_shake_256s,
+  id_slh_dsa_shake_256f,
 } from "../src";
 import { OneAsymmetricKey, Version } from "@peculiar/asn1-asym-key";
 
@@ -1348,6 +1363,37 @@ describe("x509-post-quantum", () => {
       const signatureValue = AsnConvert.parse(Buffer.from(pem, "base64"), BitString);
       const composote = AsnConvert.parse(signatureValue.value, CompositeSignatureValue);
       assert.strictEqual(composote.length, 2);
+    });
+  });
+
+  describe("FIPS 204 / FIPS 205 object identifiers", () => {
+    it("ML-DSA OIDs match NIST CSOR sigAlgs assignments", () => {
+      assert.strictEqual(id_ml_dsa_44, "2.16.840.1.101.3.4.3.17");
+      assert.strictEqual(id_ml_dsa_65, "2.16.840.1.101.3.4.3.18");
+      assert.strictEqual(id_ml_dsa_87, "2.16.840.1.101.3.4.3.19");
+    });
+
+    it("SLH-DSA OIDs match NIST CSOR sigAlgs assignments", () => {
+      assert.strictEqual(id_slh_dsa_sha2_128s, "2.16.840.1.101.3.4.3.20");
+      assert.strictEqual(id_slh_dsa_sha2_128f, "2.16.840.1.101.3.4.3.21");
+      assert.strictEqual(id_slh_dsa_sha2_192s, "2.16.840.1.101.3.4.3.22");
+      assert.strictEqual(id_slh_dsa_sha2_192f, "2.16.840.1.101.3.4.3.23");
+      assert.strictEqual(id_slh_dsa_sha2_256s, "2.16.840.1.101.3.4.3.24");
+      assert.strictEqual(id_slh_dsa_sha2_256f, "2.16.840.1.101.3.4.3.25");
+      assert.strictEqual(id_slh_dsa_shake_128s, "2.16.840.1.101.3.4.3.26");
+      assert.strictEqual(id_slh_dsa_shake_128f, "2.16.840.1.101.3.4.3.27");
+      assert.strictEqual(id_slh_dsa_shake_192s, "2.16.840.1.101.3.4.3.28");
+      assert.strictEqual(id_slh_dsa_shake_192f, "2.16.840.1.101.3.4.3.29");
+      assert.strictEqual(id_slh_dsa_shake_256s, "2.16.840.1.101.3.4.3.30");
+      assert.strictEqual(id_slh_dsa_shake_256f, "2.16.840.1.101.3.4.3.31");
+    });
+
+    it("round-trips an AlgorithmIdentifier with an ML-DSA-87 OID and absent parameters", () => {
+      const input = new AlgorithmIdentifier({ algorithm: id_ml_dsa_87 });
+      const der = AsnConvert.serialize(input);
+      const output = AsnConvert.parse(der, AlgorithmIdentifier);
+      assert.strictEqual(output.algorithm, id_ml_dsa_87);
+      assert.strictEqual(output.parameters, undefined);
     });
   });
 });


### PR DESCRIPTION
Adds object identifiers for the 15 pure signature algorithms defined by NIST FIPS 204 (ML-DSA) and FIPS 205 (SLH-DSA), registered in the NIST Computer Security Objects Register under the `sigAlgs` arc (`2.16.840.1.101.3.4.3`).

These identifiers are prerequisites for `@peculiar/x509` registering the algorithms in its AlgorithmProvider — see PeculiarVentures/x509#133. Opening this first so the constants are available to import downstream.

## Added

- `id_ml_dsa_44` / `id_ml_dsa_65` / `id_ml_dsa_87` (FIPS 204, sigAlgs .17 – .19)
- `id_slh_dsa_sha2_{128,192,256}{s,f}` (FIPS 205, sigAlgs .20 – .25)
- `id_slh_dsa_shake_{128,192,256}{s,f}` (FIPS 205, sigAlgs .26 – .31)

Per FIPS 204 §5 and FIPS 205 §9, the AlgorithmIdentifier for pure ML-DSA and SLH-DSA carries no parameters (absent, not NULL) — same encoding convention as Ed25519 (RFC 8410).

## Verification

- Unit tests assert each constant equals its NIST CSOR-registered value
- Round-trip test serializes + parses `AlgorithmIdentifier` with `id_ml_dsa_87` and confirms the OID and absent-parameters encoding