### PR TITLE
chore(ci): exclude lerna.json from oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -8,5 +8,5 @@
   "quoteProps": "as-needed",
   "sortImports": false,
   "sortPackageJson": false,
-  "ignorePatterns": ["node_modules", "coverage", ".nyc_output", "**/build/**", "*.tsbuildinfo"]
+  "ignorePatterns": ["node_modules", "coverage", ".nyc_output", "**/build/**", "*.tsbuildinfo", "lerna.json"]
 }


### PR DESCRIPTION
## Summary

- Add `lerna.json` to oxfmt `ignorePatterns` so `npm run format:check` does not fail after Lerna rewrites the file during version bumps.