### PR TITLE
ci(release): add option to force-publish all packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
           - patch
           - minor
           - major
+      publish_all:
+        description: Publish all packages, including unchanged packages
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-${{ github.ref }}
@@ -64,7 +69,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! npx lerna changed; then
+          if [ "${{ inputs.publish_all }}" = "true" ]; then
+            echo "Publishing all packages; skipping changed-package check."
+          elif ! npx lerna changed; then
             echo "No changed packages detected by Lerna." >&2
             exit 1
           fi
@@ -81,15 +88,19 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Bump versions of changed packages only
+      - name: Bump versions of selected packages
         shell: bash
         run: |
           set -euo pipefail
 
-          # Important:
-          # Do NOT add --force-publish here.
-          # Without --force-publish, Lerna updates only changed packages.
-          npx lerna version "${{ inputs.version }}" \
+          version_args=("${{ inputs.version }}")
+
+          if [ "${{ inputs.publish_all }}" = "true" ]; then
+            version_args+=(--force-publish)
+            echo "Force-publishing all packages."
+          fi
+
+          npx lerna version "${version_args[@]}" \
             --yes \
             --no-push \
             --no-git-tag-version \
@@ -181,7 +192,7 @@ jobs:
         env:
           RELEASE_TYPE: ${{ inputs.version }}
 
-      - name: Pack changed packages
+      - name: Pack packages selected for publication
         shell: bash
         run: |
           set -euo pipefail
@@ -364,12 +375,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Recreate version bump
+      - name: Recreate selected version bump
         shell: bash
         run: |
           set -euo pipefail
 
-          npx lerna version "${{ inputs.version }}" \
+          version_args=("${{ inputs.version }}")
+
+          if [ "${{ inputs.publish_all }}" = "true" ]; then
+            version_args+=(--force-publish)
+          fi
+
+          npx lerna version "${version_args[@]}" \
             --yes \
             --no-push \
             --no-git-tag-version \


### PR DESCRIPTION
## Summary

Adds a `publish_all` boolean input to the release workflow so a release run can force-publish **all** packages (including unchanged ones), instead of only the packages Lerna detects as changed.

## Changes

- Added `publish_all` input (boolean, default `false`) to `release.yml`.
- **`validate` job**: skips the "no changed packages" check when `publish_all` is set.
- **`release` job**: passes `--force-publish` to `npx lerna version` when `publish_all` is set, so all packages get a version bump.
- **`publish` job**: recreates the same version bump with `--force-publish` to keep the release and publish jobs consistent.
- Renamed step labels to reflect that they may now cover all packages, not just changed ones.

## Motivation

Useful for forced full releases (e.g., republishing an entire release train or when package change detection should be overridden).

## Testing

- Workflow-only change; validated via `npm run lint` (oxlint) and `npm run format:check` (oxfmt).
- No package source, tests, or build output were touched.