### PR TITLE
fix(schema): use root @peculiar/utils imports

### DIFF
--- a/packages/schema/src/convert.ts
+++ b/packages/schema/src/convert.ts
@@ -1,5 +1,5 @@
 import * as asn1js from "asn1js";
-import { type BufferSourceLike, isBufferSource, toArrayBuffer } from "@peculiar/utils/bytes";
+import { type BufferSourceLike, isBufferSource, toArrayBuffer } from "@peculiar/utils";
 import { AsnParser } from "./parser";
 import { IEmptyConstructor, IAsnParseOptions } from "./types";
 import { AsnSerializer } from "./serializer";

--- a/packages/schema/src/converters.ts
+++ b/packages/schema/src/converters.ts
@@ -1,5 +1,5 @@
 import * as asn1js from "asn1js";
-import { toArrayBuffer } from "@peculiar/utils/bytes";
+import { toArrayBuffer } from "@peculiar/utils";
 import { AnyConverterType, IAsnConverter, IntegerConverterType } from "./types";
 import { AsnPropTypes } from "./enums";
 import { OctetString } from "./types/index";

--- a/packages/schema/src/parser.ts
+++ b/packages/schema/src/parser.ts
@@ -1,5 +1,5 @@
 import * as asn1js from "asn1js";
-import { type BufferSourceLike, toArrayBuffer } from "@peculiar/utils/bytes";
+import { type BufferSourceLike, toArrayBuffer } from "@peculiar/utils";
 import { AsnPropTypes, AsnTypeTypes } from "./enums";
 import * as converters from "./converters";
 import { AsnSchemaValidationError } from "./errors";

--- a/packages/schema/src/serializer.ts
+++ b/packages/schema/src/serializer.ts
@@ -1,5 +1,5 @@
 import * as asn1js from "asn1js";
-import { toArrayBuffer } from "@peculiar/utils/bytes";
+import { toArrayBuffer } from "@peculiar/utils";
 import * as converters from "./converters";
 import { AsnPropTypes, AsnTypeTypes } from "./enums";
 import { isConvertible, isArrayEqual } from "./helper";

--- a/packages/schema/src/types/bit_string.ts
+++ b/packages/schema/src/types/bit_string.ts
@@ -1,5 +1,5 @@
 import * as asn1js from "asn1js";
-import { isBufferSource, toArrayBuffer, type BufferSourceLike } from "@peculiar/utils/bytes";
+import { isBufferSource, toArrayBuffer, type BufferSourceLike } from "@peculiar/utils";
 import { IAsnConvertible } from "../types";
 
 export class BitString<T extends number = number> implements IAsnConvertible {

--- a/packages/schema/src/types/octet_string.ts
+++ b/packages/schema/src/types/octet_string.ts
@@ -1,5 +1,5 @@
 import * as asn1js from "asn1js";
-import { BufferSourceLike, isBufferSource, toArrayBuffer } from "@peculiar/utils/bytes";
+import { BufferSourceLike, isBufferSource, toArrayBuffer } from "@peculiar/utils";
 import { IAsnConvertible } from "../types";
 
 // Implement ArrayBufferView, cause ES5 doesn't allow to extend ArrayBuffer class

--- a/packages/schema/test/test.ts
+++ b/packages/schema/test/test.ts
@@ -1,6 +1,6 @@
 import * as assert from "node:assert";
 import * as asn1js from "asn1js";
-import type { BufferSourceLike } from "@peculiar/utils/bytes";
+import type { BufferSourceLike } from "@peculiar/utils";
 import * as src from "../src";
 
 function assertBuffer(actual: Buffer, expected: Buffer): void {


### PR DESCRIPTION
## Summary

- replace `@peculiar/utils/bytes` imports with imports from `@peculiar/utils`
- fix TypeScript builds with `moduleResolution: "node"`
- preserve existing runtime behavior

With the previous imports, downstream projects using TypeScript 5.9 and classic Node module resolution failed with `TS2307` errors while resolving `@peculiar/utils/bytes`.

## Validation

- verified a temporary consumer project with TypeScript 5.9.3 and `moduleResolution: "node"`