### PR TITLE
chore(packages): add node engine requirement to all packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8799,6 +8799,9 @@
       "name": "@peculiar/asn1-adobe-acrobat",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -8810,6 +8813,9 @@
       "name": "@peculiar/asn1-android",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "asn1js": "^3.0.10",
@@ -8820,6 +8826,9 @@
       "name": "@peculiar/asn1-apple",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "asn1js": "^3.0.10",
@@ -8830,6 +8839,9 @@
       "name": "@peculiar/asn1-asym-key",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-pkcs8": "^2.9.3",
         "@peculiar/asn1-schema": "^2.9.3",
@@ -8842,6 +8854,9 @@
       "name": "@peculiar/asn1-cert-transparency",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-tls": "^2.9.3",
@@ -8854,6 +8869,9 @@
       "name": "@peculiar/asn1-cms",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -8866,6 +8884,9 @@
       "name": "@peculiar/asn1-crmf",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-cms": "^2.9.3",
         "@peculiar/asn1-schema": "^2.9.3",
@@ -8878,6 +8899,9 @@
       "name": "@peculiar/asn1-csr",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -8889,6 +8913,9 @@
       "name": "@peculiar/asn1-ecc",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -8900,6 +8927,9 @@
       "name": "@peculiar/asn1-ess",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-cms": "^2.9.3",
         "@peculiar/asn1-pkcs9": "^2.9.3",
@@ -8914,6 +8944,9 @@
       "name": "@peculiar/asn1-lei",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "asn1js": "^3.0.10",
@@ -8924,6 +8957,9 @@
       "name": "@peculiar/asn1-mtc",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-tls": "^2.9.3",
@@ -8937,6 +8973,9 @@
       "name": "@peculiar/asn1-ntqwac",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -8948,6 +8987,9 @@
       "name": "@peculiar/asn1-ocsp",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -8959,6 +9001,9 @@
       "name": "@peculiar/asn1-pfx",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-cms": "^2.9.3",
         "@peculiar/asn1-pkcs8": "^2.9.3",
@@ -8972,6 +9017,9 @@
       "name": "@peculiar/asn1-pkcs8",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -8983,6 +9031,9 @@
       "name": "@peculiar/asn1-pkcs9",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-cms": "^2.9.3",
         "@peculiar/asn1-pfx": "^2.9.3",
@@ -8998,6 +9049,9 @@
       "name": "@peculiar/asn1-private-key-stmt",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-cms": "^2.9.3",
         "@peculiar/asn1-schema": "^2.9.3",
@@ -9010,6 +9064,9 @@
       "name": "@peculiar/asn1-rfc8226",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "asn1js": "^3.0.10",
@@ -9020,6 +9077,9 @@
       "name": "@peculiar/asn1-rsa",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -9031,6 +9091,9 @@
       "name": "@peculiar/asn1-schema",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.10",
@@ -9041,6 +9104,9 @@
       "name": "@peculiar/asn1-tls",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
         "tslib": "^2.8.1"
@@ -9050,6 +9116,9 @@
       "name": "@peculiar/asn1-tsp",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-cms": "^2.9.3",
         "@peculiar/asn1-schema": "^2.9.3",
@@ -9062,6 +9131,9 @@
       "name": "@peculiar/asn1-x509",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/utils": "^2.0.2",
@@ -9073,6 +9145,9 @@
       "name": "@peculiar/asn1-x509-attr",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -9084,6 +9159,9 @@
       "name": "@peculiar/asn1-x509-logotype",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -9095,6 +9173,9 @@
       "name": "@peculiar/asn1-x509-microsoft",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -9107,6 +9188,9 @@
       "name": "@peculiar/asn1-x509-netscape",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "asn1js": "^3.0.10",
@@ -9117,6 +9201,9 @@
       "name": "@peculiar/asn1-x509-post-quantum",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-asym-key": "^2.9.3",
         "@peculiar/asn1-schema": "^2.9.3",
@@ -9129,6 +9216,9 @@
       "name": "@peculiar/asn1-x509-qualified",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",
@@ -9140,6 +9230,9 @@
       "name": "@peculiar/asn1-x509-qualified-etsi",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "asn1js": "^3.0.10",
@@ -9150,6 +9243,9 @@
       "name": "@peculiar/asn1-x509-trustanchor",
       "version": "2.9.3",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
       "dependencies": {
         "@peculiar/asn1-schema": "^2.9.3",
         "@peculiar/asn1-x509": "^2.9.3",

--- a/packages/adobe-acrobat/package.json
+++ b/packages/adobe-acrobat/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/apple/package.json
+++ b/packages/apple/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/asym-key/package.json
+++ b/packages/asym-key/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/cert-transparency/package.json
+++ b/packages/cert-transparency/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/crmf/package.json
+++ b/packages/crmf/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/csr/package.json
+++ b/packages/csr/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/ecc/package.json
+++ b/packages/ecc/package.json
@@ -14,6 +14,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/ess/package.json
+++ b/packages/ess/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/lei/package.json
+++ b/packages/lei/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/mtc/package.json
+++ b/packages/mtc/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/ntqwac/package.json
+++ b/packages/ntqwac/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/ocsp/package.json
+++ b/packages/ocsp/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/pfx/package.json
+++ b/packages/pfx/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/pkcs8/package.json
+++ b/packages/pkcs8/package.json
@@ -11,6 +11,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/pkcs9/package.json
+++ b/packages/pkcs9/package.json
@@ -11,6 +11,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/private-key-stmt/package.json
+++ b/packages/private-key-stmt/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/rfc8226/package.json
+++ b/packages/rfc8226/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/rsa/package.json
+++ b/packages/rsa/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/tls/package.json
+++ b/packages/tls/package.json
@@ -10,6 +10,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/tsp/package.json
+++ b/packages/tsp/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/x509-attr/package.json
+++ b/packages/x509-attr/package.json
@@ -11,6 +11,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/x509-logotype/package.json
+++ b/packages/x509-logotype/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/x509-microsoft/package.json
+++ b/packages/x509-microsoft/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/x509-netscape/package.json
+++ b/packages/x509-netscape/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/x509-post-quantum/package.json
+++ b/packages/x509-post-quantum/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/x509-qualified-etsi/package.json
+++ b/packages/x509-qualified-etsi/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/x509-qualified/package.json
+++ b/packages/x509-qualified/package.json
@@ -11,6 +11,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/x509-trustanchor/package.json
+++ b/packages/x509-trustanchor/package.json
@@ -11,6 +11,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/packages/x509/package.json
+++ b/packages/x509/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "PeculiarVentures, LLC",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "files": [
     "build/**/*.{js,d.ts}",
     "build/es2015/package.json",

--- a/scripts/create_package.mjs
+++ b/scripts/create_package.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import * as rimraf from "rimraf";
 
 const COMMON_FILES = ["build/**/*.{js,d.ts}", "build/es2015/package.json", "LICENSE", "README.md"];
+const PACKAGE_ENGINES = { node: ">=14" };
 
 const COMMON_SCRIPTS = {
   clear: "rimraf build",
@@ -78,6 +79,7 @@ function createPackageJson(packageJson, name, moduleName) {
     ["keywords", createPackageKeywords(name)],
     ["author", "PeculiarVentures, LLC"],
     ["license", "MIT"],
+    ["engines", PACKAGE_ENGINES],
     ["files", COMMON_FILES],
     ["main", "build/cjs/index.js"],
     ["module", "build/es2015/index.js"],


### PR DESCRIPTION
## Description

Adds a `engines` field with `node: ">=14"` to all packages in the monorepo, and updates `scripts/create_package.mjs` so newly scaffolded packages get the same engine requirement by default.

This makes the supported Node version explicit for consumers installing individual packages, and keeps the scaffolding script consistent with existing packages.

## Changes

- Add `"engines": { "node": ">=14" }` to all `packages/*/package.json`
- Update `scripts/create_package.mjs` to include the engines field for new packages
- Regenerate `package-lock.json`